### PR TITLE
Refactor loadEnvironment to conditionally load .env based on file existence

### DIFF
--- a/src/core/config/load-environment.ts
+++ b/src/core/config/load-environment.ts
@@ -1,16 +1,15 @@
 import dotenv from 'dotenv';
+import fs from 'fs';
 
 export function loadEnvironment(): void {
-  if (process.env.IS_DOCKER) {
-    console.log('Running inside Docker, skipping .env loading');
+  if (!fs.existsSync('.env')) {
+    console.log('.env file does not exist, skipping dotenv configuration.');
     return;
   }
 
-  const result: dotenv.DotenvConfigOutput = dotenv.config();
-
+  const result = dotenv.config();
   if (result.error) {
     throw result.error;
   }
-
   console.log('Environment variables loaded from .env file');
 }


### PR DESCRIPTION
- Updated the `loadEnvironment` function to check for the existence of a `.env` file using `fs.existsSync` instead of relying on the `IS_DOCKER` environment variable.
- If the `.env` file is not present, the function skips loading environment variables, which makes the behavior more automatic in environments like Docker.
- Modified the test suite to mock `fs.existsSync` accordingly, ensuring that both scenarios (file exists or not) are properly validated.